### PR TITLE
Bump app version to 1.0.6

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.tewelde.rijksmuseum"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 5
-        versionName = "1.0.5"
+        versionCode = 6
+        versionName = "1.0.6"
     }
     packaging {
         resources {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.5</string>
+	<string>1.0.6</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## Summary

Version bump for the 1.0.6 release containing:
- Linked Art API migration (#121)
- Dependency upgrade (Kotlin 2.3.21, Compose 1.11.0, Ktor 3.5.0, etc.) (#125 part 1)
- AGP 9.2.1 + Gradle 9.5.1 + module restructure (composeApp → shared + per-platform apps) (#125 part 2)

Touches:
- `androidApp/build.gradle.kts`: `versionCode 5 → 6`, `versionName "1.0.5" → "1.0.6"`
- `iosApp/iosApp/Info.plist`: `CFBundleVersion 5 → 6`, `CFBundleShortVersionString 1.0.5 → 1.0.6`

(Rebased onto main after #125 merged — the original bump targeted the now-deleted `composeApp/build.gradle.kts`; relocated to `androidApp/build.gradle.kts` where the `defaultConfig` block now lives.)

## Test plan

- [ ] Merge, then verify the `v1.0.6` git tag (already force-updated to the rebased commit) is on the merge commit. If GitHub squash-merges, retag with `git tag -f v1.0.6 <merge-sha> && git push -f origin v1.0.6`.
- [ ] Upload signed AAB to Play Console (internal track first).
- [ ] Archive iOS build in Xcode, upload to App Store Connect (TestFlight first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)