### PR TITLE
Fix Pages deploy: composeApp → webApp, JDK 17 → 21

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Retrieve the secret and decode it to a file
         env:
@@ -39,12 +39,12 @@ jobs:
 
       - name: Build Page
         run: |
-          ./gradlew wasmJsBrowserDistribution --no-configuration-cache
+          ./gradlew :webApp:wasmJsBrowserDistribution --no-configuration-cache
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: 'composeApp/build/dist/wasmJs/productionExecutable'
+          path: 'webApp/build/dist/wasmJs/productionExecutable'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary

Fixes [run 26419959640](https://github.com/fethij/Rijksmuseum/actions/runs/26419959640) which failed with:

\`\`\`
tar: composeApp/build/dist/wasmJs/productionExecutable: Cannot open: No such file or directory
\`\`\`

PR #125 restructured the project (composeApp split into \`shared\` + \`androidApp\` + \`desktopApp\` + \`webApp\`). The Pages workflow was still pointing at the old paths:

| | before | after |
|---|---|---|
| Upload path | \`composeApp/build/dist/wasmJs/productionExecutable\` | \`webApp/build/dist/wasmJs/productionExecutable\` |
| Gradle task | \`wasmJsBrowserDistribution\` (root, ambiguous) | \`:webApp:wasmJsBrowserDistribution\` |
| JDK | 17 | 21 |

JDK bump is because \`androidApp\`'s \`compileOptions\` are pinned to \`JavaVersion.VERSION_21\` and Gradle configures all modules during evaluation, so the runner needs ≥ 21 even if the wasm task itself doesn't touch Android compilation.

## Test plan

- [ ] CI runs `:webApp:wasmJsBrowserDistribution` green
- [ ] Pages artifact upload succeeds
- [ ] Site at https://fethij.github.io/Rijksmuseum/ updates and the IIIF images load

🤖 Generated with [Claude Code](https://claude.com/claude-code)